### PR TITLE
Static linking option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,6 +133,16 @@ AC_ARG_ENABLE([examples],
 AM_CONDITIONAL(ENABLE_EXAMPLES, test "x${enable_examples}" = "xyes")
 
 dnl ------------------------------------------------------------------
+dnl Static
+dnl ------------------------------------------------------------------
+
+AC_ARG_ENABLE([static],
+	AC_HELP_STRING([--enable-static],
+	    [link with zeromq static library [[default=no]]]),,
+	enable_static="no")
+AM_CONDITIONAL(ENABLE_STATIC, test "x${enable_static}" = "xyes")
+
+dnl ------------------------------------------------------------------
 dnl ZeroMQ
 dnl ------------------------------------------------------------------
 
@@ -148,12 +158,19 @@ Use the '--with-zeromq=PATH' option to specify location of ZeroMQ])])
 
 CXXFLAGS="${CXXFLAGS# } -I${with_zeromq}/include"
 
-case "${host_os}" in
-    *darwin*)
-    LDFLAGS="${LDFLAGS# } -L${with_zeromq}/lib -lzmq"
+case "${enable_static}" in
+    *yes*)
+    LDFLAGS="${LDFLAGS# } ${with_zeromq}/lib/libzmq.a"
     ;;
     *)
-    LDFLAGS="${LDFLAGS# } -L${with_zeromq}/lib -lzmq -Wl,-R${with_zeromq}/lib"
+    case "${host_os}" in
+        *darwin*)
+            LDFLAGS="${LDFLAGS# } -L${with_zeromq}/lib -lzmq"
+        ;;
+        *)
+            LDFLAGS="${LDFLAGS# } -L${with_zeromq}/lib -lzmq -Wl,-R${with_zeromq}/lib"
+        ;;
+    esac
     ;;
 esac
 
@@ -212,4 +229,8 @@ echo
 AC_MSG_NOTICE([    Debug/warnings:     ${enable_debug}/${enable_warnings}])
 AC_MSG_NOTICE([    Documentation:      ${enable_docs}])
 AC_MSG_NOTICE([    Examples:           ${enable_examples}])
+
+echo
+AC_MSG_NOTICE([    Static:              ${enable_static}])
+
 echo


### PR DESCRIPTION
Hi,

I have added an option that allows linking statically against libzmq. I normally prefer when my application files are more or less self sufficient, especially when it comes to libraries that are not normally installed by default.

Would you consider merging this in?

Thanks!
